### PR TITLE
write to TestContext progressively

### DIFF
--- a/src/Serilog.Sinks.NUnit/Sinks/NUnit/NUnitSink.cs
+++ b/src/Serilog.Sinks.NUnit/Sinks/NUnit/NUnitSink.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.NUnit
                 var writer = new StringWriter();
                 _formatter.Format(logEvent, writer);
 
-                TestContext.Out.WriteLine(writer.ToString());
+                TestContext.Progress.WriteLine(writer.ToString());
             }
         }
     }


### PR DESCRIPTION
The output is not blocked until the test execution and appears as it is produced progressively