### PR TITLE
Removal of additional line break at the end of message

### DIFF
--- a/src/Serilog.Sinks.NUnit/Sinks/NUnit/NUnitSink.cs
+++ b/src/Serilog.Sinks.NUnit/Sinks/NUnit/NUnitSink.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.NUnit
                 var writer = new StringWriter();
                 _formatter.Format(logEvent, writer);
 
-                TestContext.Progress.WriteLine(writer.ToString());
+                TestContext.Progress.Write(writer.ToString());
             }
         }
     }


### PR DESCRIPTION
TestContext.Progress.WriteLine is unneeded as formatted serilog message already contains line break at the end.
See: https://github.com/serilog/serilog-sinks-console/blob/eafe7d50cd9c2255b25ce3110eee8382ae5c0561/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs#L66